### PR TITLE
Fix ResourceProcessor to handle multiple Resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 hs_err_pid*
 /SpringRessourceProcessor.iml
 /.idea/
+
+target

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,22 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-starter-parent</artifactId>
-        <version>Brixton.M5</version>
-        <relativePath />
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.5.2.RELEASE</version>
     </parent>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>Dalston.SR1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <groupId>de.wilms.springtest</groupId>
     <artifactId>SpringRessourceProcessor</artifactId>
@@ -75,7 +86,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.7.1</version>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
@@ -95,7 +105,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-search-orm</artifactId>
-            <version>5.3.0.Final</version>
+            <version>5.4.0.Final</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -107,12 +117,10 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-            <version>1.0.0.GA</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>4.3.1.Final</version>
         </dependency>
 
         <dependency>
@@ -127,22 +135,6 @@
         </dependency>
 
     </dependencies>
-
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <artifactId>spring-data-rest-webmvc</artifactId>
-                <groupId>org.springframework.data</groupId>
-                <version>2.5.0.RELEASE</version>
-            </dependency>
-            <dependency>
-                <artifactId>spring-data-rest-core</artifactId>
-                <groupId>org.springframework.data</groupId>
-                <version>2.5.0.RELEASE</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/src/main/java/de/wilms/springtest/ResourceProcessorApplication.java
+++ b/src/main/java/de/wilms/springtest/ResourceProcessorApplication.java
@@ -1,23 +1,13 @@
 package de.wilms.springtest;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.orm.jpa.EntityScan;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 /**
  * Copyright (c): it@M - Dienstleister für Informations- und Telekommunikationstechnik
  * der Landeshauptstadt München, 2017
  */
-@Configuration
-@ComponentScan
-@EntityScan
-@EnableJpaRepositories
-@EnableAutoConfiguration
-@EnableHypermediaSupport(type = EnableHypermediaSupport.HypermediaType.HAL)
+@SpringBootApplication
 public class ResourceProcessorApplication {
 
     public static void main(String[] args) throws Exception {

--- a/src/main/java/de/wilms/springtest/processors/CitizenResourcesProcessor.java
+++ b/src/main/java/de/wilms/springtest/processors/CitizenResourcesProcessor.java
@@ -1,17 +1,23 @@
 package de.wilms.springtest.processors;
 
 import de.wilms.springtest.entities.Citizen;
+
+import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.ResourceProcessor;
 import org.springframework.hateoas.Resources;
 import org.springframework.stereotype.Component;
 
+/**
+ * Because Spring Data REST wraps things as {@literal Resources<Resource<T>>}, that is the type you must
+ * match when writing a custom {@link ResourceProcessor}. --Greg Turnquist
+ */
 @Component
-public class CitizenResourcesProcessor implements ResourceProcessor<Resources<Citizen>> {
+public class CitizenResourcesProcessor implements ResourceProcessor<Resources<Resource<Citizen>>> {
 
     public static boolean GOT_CALLED = false;
 
     @Override
-    public Resources<Citizen> process(Resources<Citizen> citizens) {
+    public Resources<Resource<Citizen>> process(Resources<Resource<Citizen>> citizens) {
         System.out.println("Hello from the ResourceSSSSProcessor!");
         GOT_CALLED = true;
         return citizens;

--- a/src/test/java/ResourceProcessorTests.java
+++ b/src/test/java/ResourceProcessorTests.java
@@ -1,3 +1,9 @@
+import static org.junit.Assert.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.UUID;
+
 import de.wilms.springtest.ResourceProcessorApplication;
 import de.wilms.springtest.entities.Citizen;
 import de.wilms.springtest.processors.CitizenResourceProcessor;
@@ -8,24 +14,17 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = ResourceProcessorApplication.class)
+@SpringBootTest(classes = ResourceProcessorApplication.class)
 @WebAppConfiguration
 public class ResourceProcessorTests {
 
@@ -86,7 +85,7 @@ public class ResourceProcessorTests {
         mockMvc.perform(get(urlTemplate))
                 .andExpect(status().isOk());
 
-        assertFalse(CitizenResourceProcessor.GOT_CALLED);
+        assertTrue(CitizenResourceProcessor.GOT_CALLED);
         assertTrue(CitizenResourcesProcessor.GOT_CALLED);
         assertTrue(ResourceSupportResourceProcessor.GOT_CALLED);
     }


### PR DESCRIPTION
* Bump things up to latest Spring Boot stable release to ensure we're using latest version of Spring Data + Spring HATEOAS
* Fix CitizensResourcesProcessor to use `Resources<Resource<Citizen>>` instead of `Resources<Citizen>`.